### PR TITLE
fix - decode: extract length

### DIFF
--- a/esm/decode.js
+++ b/esm/decode.js
@@ -6,8 +6,9 @@
  */
 export const decode = async (bota, format = 'deflate') => {
   const str = atob(bota);
-  const buffer = new Uint8Array(str.length);
-  for (let i = 0; i < str.length; i++)
+  const strLength = str.length;
+  const buffer = new Uint8Array(strLength);
+  for (let i = 0; i < strLength; i++)
     buffer[i] = str.charCodeAt(i);
   let response = new Blob([buffer]);
   if (format) {
@@ -16,4 +17,3 @@ export const decode = async (bota, format = 'deflate') => {
   }
   return await new Response(response).arrayBuffer();
 };
-  


### PR DESCRIPTION
For the same reason I've opened the other PR, I would like to speed up performances of the decode function by extracting the length of the string.